### PR TITLE
fix: stale reference to onScroll and onLoad

### DIFF
--- a/src/MasonryFlashList.tsx
+++ b/src/MasonryFlashList.tsx
@@ -114,6 +114,9 @@ const MasonryFlashListComponent = React.forwardRef(
 
     const totalColumnFlex = useTotalColumnFlex(dataSet, props);
 
+    const propsRef = useRef(props);
+    propsRef.current = props;
+
     const onScrollRef = useRef<OnScrollCallback[]>([]);
     const emptyScrollEvent = useRef(getEmptyScrollEvent())
       .current as NativeSyntheticEvent<MasonryFlashListScrollEvent>;
@@ -135,7 +138,7 @@ const MasonryFlashListComponent = React.forwardRef(
           onScrollCallback?.(emptyScrollEvent);
         });
         if (!scrollEvent.nativeEvent.doNotPropagate) {
-          props.onScroll?.(scrollEvent);
+          propsRef.current.onScroll?.(scrollEvent);
         }
       }
     ).current;
@@ -151,7 +154,7 @@ const MasonryFlashListComponent = React.forwardRef(
         onScrollProxy?.(emptyScrollEvent);
         emptyScrollEvent.nativeEvent.doNotPropagate = false;
       }, 32);
-      props.onLoad?.(args);
+      propsRef.current.onLoad?.(args);
     }).current;
 
     const [parentFlashList, getFlashList] =


### PR DESCRIPTION
# Summary
fix: stale reference to onScroll and onLoad


## Test Plan
![a2818e6244094e1bd85814b39f82586](https://github.com/user-attachments/assets/58286078-86f3-486a-bfd7-9780aadc94be)

![f78208eb2f76466ce93520425b519b8](https://github.com/user-attachments/assets/5ffa5930-ca64-468a-ada5-889530d634aa)



## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
