### PR TITLE
fix：解决npm publish版本发布的语法报错问题

### DIFF
--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -652,7 +652,7 @@ class FlashList<T> extends React.PureComponent<
       index,
       target,
       extraData: this.state.extraData?.value,
-    }) as JSX.Element;
+    }) as React.ReactElement;
   };
 
   /**

--- a/src/MasonryFlashList.tsx
+++ b/src/MasonryFlashList.tsx
@@ -471,6 +471,6 @@ MasonryFlashListComponent.displayName = "MasonryFlashList";
  */
 export const MasonryFlashList = MasonryFlashListComponent as <T>(
   props: MasonryFlashListProps<T> & {
-    ref?: React.RefObject<MasonryFlashListRef<T>>;
+    ref?: React.RefObject<MasonryFlashListRef<T> | null>;
   }
 ) => React.ReactElement;

--- a/src/PureComponentWrapper.tsx
+++ b/src/PureComponentWrapper.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export interface PureComponentWrapperProps {
-  renderer: (arg: unknown) => JSX.Element | null;
+  renderer: (arg: unknown) => React.ReactElement | null;
 
   /** Renderer is called with this argument.
    * Don't change this value everytime or else component will always rerender. Prefer primitives. */

--- a/src/__tests__/helpers/mountFlashList.tsx
+++ b/src/__tests__/helpers/mountFlashList.tsx
@@ -45,7 +45,7 @@ export const mountFlashList = (
 
 export function renderFlashList(
   props?: MockFlashListProps,
-  ref?: React.RefObject<FlashList<string>>
+  ref?: React.RefObject<FlashList<string> | null>
 ) {
   return (
     <FlashList

--- a/src/__tests__/helpers/mountMasonryFlashList.tsx
+++ b/src/__tests__/helpers/mountMasonryFlashList.tsx
@@ -42,7 +42,7 @@ export type MockMasonryFlashListProps = Omit<
  */
 export const mountMasonryFlashList = (
   props?: MockMasonryFlashListProps,
-  ref?: React.RefObject<MasonryFlashListRef<string>>
+  ref?: React.RefObject<MasonryFlashListRef<string> | null>
 ) => {
   const flashList = mount(renderMasonryFlashList(props, ref)) as Omit<
     Root<MasonryFlashListProps<string>>,
@@ -55,7 +55,7 @@ export const mountMasonryFlashList = (
 
 export function renderMasonryFlashList(
   props?: MockMasonryFlashListProps,
-  ref?: React.RefObject<MasonryFlashListRef<string>>
+  ref?: React.RefObject<MasonryFlashListRef<string> | null>
 ) {
   return (
     <MasonryFlashList

--- a/src/__tests__/useBlankAreaTracker.test.tsx
+++ b/src/__tests__/useBlankAreaTracker.test.tsx
@@ -14,7 +14,7 @@ type BlankTrackingFlashListProps = MockFlashListProps & {
   onCumulativeBlankAreaResult?: (result: BlankAreaTrackerResult) => void;
   onCumulativeBlankAreaChange?: (updatedResult: BlankAreaTrackerResult) => void;
   blankAreaTrackerConfig?: BlankAreaTrackerConfig;
-  instance?: React.RefObject<FlashList<any>>;
+  instance?: React.RefObject<FlashList<any> | null>;
 };
 
 const BlankTrackingFlashList = (props?: BlankTrackingFlashListProps) => {
@@ -41,9 +41,7 @@ const BlankTrackingFlashList = (props?: BlankTrackingFlashListProps) => {
 };
 
 const mountBlankTrackingFlashList = (props?: BlankTrackingFlashListProps) => {
-  const flashListRef: React.RefObject<FlashList<any>> = {
-    current: null,
-  };
+  const flashListRef = React.createRef<FlashList<any>>();
   const blankTrackingFlashList = mount(
     <BlankTrackingFlashList {...props} instance={flashListRef} />
   );

--- a/src/benchmark/useBlankAreaTracker.ts
+++ b/src/benchmark/useBlankAreaTracker.ts
@@ -35,7 +35,7 @@ export interface BlankAreaTrackerConfig {
  * @returns blankAreaTrackerResult - maxBlankArea, cumulativeBlankArea this object is mutated and kept up to date. Also returns a callback that needs to be forwarded to FlashList.
  */
 export function useBlankAreaTracker(
-  flashListRef: React.RefObject<FlashList<any>>,
+  flashListRef: React.RefObject<FlashList<any> | null>,
   onBlankAreaChange?: (value: BlankAreaTrackerResult) => void,
   config?: BlankAreaTrackerConfig
 ): [BlankAreaTrackerResult, (event: BlankAreaEvent) => void] {


### PR DESCRIPTION


# Summary

- fix：解决npm publish版本发布的语法报错问题

## Test Plan

<img width="1072" height="746" alt="image" src="https://github.com/user-attachments/assets/a9a97a59-c6ca-48c2-9f5d-d894067333ae" />


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [ ] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
